### PR TITLE
CI: Add tarball release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.19
+
+    - name: Build
+      run: |
+        go build -o fsguard
+
+    - name: Upload a Release Asset
+      uses: softprops/action-gh-release@v1
+      with:
+        files: fsguard


### PR DESCRIPTION
This PR adds an workflow to automatically generate a new tarball release whenever a new tag starting with "v" (e.g. `v0.1`) is created. 