### PR TITLE
Signcheck + README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ This Filelist can be placed anywhere, as long as FsGuard has access to it when i
 FsGuard expects a minisign signature and filelist to be appended to the binary. An example signature "set" can be found [here](https://github.com/linux-immutability-tools/FsGuard/blob/main/signatures).
 A signature set can be generated and added to FsGuard with these commands:
 ```bash
-#!/bin/sh
 # Create a new passwordless key pair
 minisign -WG
 # Signing the filelist

--- a/README.md
+++ b/README.md
@@ -24,16 +24,18 @@ This Filelist can be placed anywhere, as long as FsGuard has access to it when i
 FsGuard expects a minisign signature and filelist to be appended to the binary. An example signature "set" can be found [here](https://github.com/linux-immutability-tools/FsGuard/blob/main/signatures).
 A signature set can be generated and added to FsGuard with these commands:
 ```bash
+#!/bin/sh
+# Create a new passwordless key pair
+minisign -WG
 # Signing the filelist
-minisign -G
 minisign -Sm /path/to/filelist
 
 # Generate the signature set
 touch /path/to/signature
-echo -e "----begin attach----" >> /path/to/signature
-cat /path/to/filelist.minisign >> /path/to/signature
-echo -e "----begin second attach----" >> /path/to/signature
-cat ./minisign.pub >> /path/to/signature
+echo -n "----begin attach----" >> /path/to/signature
+cat /path/to/filelist.minisig >> /path/to/signature
+echo -n "----begin second attach----" >> /path/to/signature
+tail -n1 ./minisign.pub >> /path/to/signature
 
 # Append the signature set to the FsGuard binary
 cat /path/to/signature >> /path/to/FsGuard

--- a/core/signcheck.go
+++ b/core/signcheck.go
@@ -16,8 +16,8 @@ func GetSignatureFile(binary string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	signatureFileIndex := bytes.Index(data, signatureFileSeparator) + len(signatureFileSeparator)
-	signatureFileEndIndex := bytes.Index(data, signatureFileEndSeparator) + len(signatureFileEndSeparator)
+	signatureFileIndex := bytes.LastIndex(data, signatureFileSeparator) + len(signatureFileSeparator)
+	signatureFileEndIndex := bytes.LastIndex(data, signatureFileEndSeparator) + len(signatureFileEndSeparator)
 	signatureFile := ""
 	for i := 0; i < signatureFileEndIndex-signatureFileIndex-len(signatureFileEndSeparator); i++ {
 		signatureFile = signatureFile + string(data[signatureFileIndex+i])
@@ -36,7 +36,7 @@ func GetSignatureHash(binary string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	signatureHashIndex := bytes.Index(data, signatureHashSeparator) + len(signatureHashSeparator)
+	signatureHashIndex := bytes.LastIndex(data, signatureHashSeparator) + len(signatureHashSeparator)
 
 	signatureHash := ""
 


### PR DESCRIPTION
This PR fixes the issue where FsGuard would parse the hardcoded `signatureFileSeparator` variable in the binary as the beginning of the signature, as well as the filelist signing example in README.