### PR TITLE
validate: Check if file exists first

### DIFF
--- a/core/signcheck.go
+++ b/core/signcheck.go
@@ -3,50 +3,58 @@ package core
 import (
 	"bytes"
 	"fmt"
-	"github.com/jedisct1/go-minisign"
 	"os"
 	"strings"
+
+	"github.com/jedisct1/go-minisign"
+)
+
+var (
+	signatureFileSeparator    = []byte("----begin attach----")
+	signatureFileEndSeparator = []byte("----begin second attach----")
+	signatureHashSeparator    = []byte("----begin second attach----")
 )
 
 func GetSignatureFile(binary string) (string, error) {
-	signatureFileSeparator := []byte{0x2D, 0x2D, 0x2D, 0x2D, 0x62, 0x65, 0x67, 0x69, 0x6E, 0x20, 0x61, 0x74, 0x74, 0x61, 0x63, 0x68, 0x2D, 0x2D, 0x2D, 0x2D}
-	signatureFileEndSeparator := []byte{0x2D, 0x2D, 0x2D, 0x2D, 0x62, 0x65, 0x67, 0x69, 0x6E, 0x20, 0x73, 0x65, 0x63, 0x6F, 0x6E, 0x64, 0x20, 0x61, 0x74, 0x74, 0x61, 0x63, 0x68, 0x2D, 0x2D, 0x2D, 0x2D}
-
 	data, err := os.ReadFile(binary)
 	if err != nil {
 		return "", err
 	}
+
 	signatureFileIndex := bytes.LastIndex(data, signatureFileSeparator) + len(signatureFileSeparator)
 	signatureFileEndIndex := bytes.LastIndex(data, signatureFileEndSeparator) + len(signatureFileEndSeparator)
 	signatureFile := ""
+
 	for i := 0; i < signatureFileEndIndex-signatureFileIndex-len(signatureFileEndSeparator); i++ {
 		signatureFile = signatureFile + string(data[signatureFileIndex+i])
 	}
+
 	if strings.TrimSpace(signatureFile) == "" {
 		fmt.Println("NO SIGNATURE FILE")
 		return "", fmt.Errorf("no signature file found")
 	}
+
 	return strings.Replace(signatureFile, "----begin second attach---", "", 1), nil
 }
 
 func GetSignatureHash(binary string) (string, error) {
-	signatureHashSeparator := []byte{0x2D, 0x2D, 0x2D, 0x2D, 0x62, 0x65, 0x67, 0x69, 0x6E, 0x20, 0x73, 0x65, 0x63, 0x6F, 0x6E, 0x64, 0x20, 0x61, 0x74, 0x74, 0x61, 0x63, 0x68, 0x2D, 0x2D, 0x2D, 0x2D}
-
 	data, err := os.ReadFile(binary)
 	if err != nil {
 		return "", err
 	}
-	signatureHashIndex := bytes.LastIndex(data, signatureHashSeparator) + len(signatureHashSeparator)
 
+	signatureHashIndex := bytes.LastIndex(data, signatureHashSeparator) + len(signatureHashSeparator)
 	signatureHash := ""
 
 	for i := 0; i < len(data)-signatureHashIndex; i++ {
 		signatureHash = signatureHash + string(data[signatureHashIndex+i])
 	}
+
 	if strings.TrimSpace(signatureHash) == "" {
 		fmt.Println("NO SIGNATURE HASH")
 		return "", fmt.Errorf("no signature hash found")
 	}
+
 	return strings.Replace(signatureHash, "----begin attach---", "", 1), nil
 }
 

--- a/core/validate.go
+++ b/core/validate.go
@@ -3,12 +3,13 @@ package core
 import (
 	"crypto/sha1"
 	"fmt"
-	"github.com/linux-immutability-tools/FsGuard/config"
 	"io"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/linux-immutability-tools/FsGuard/config"
 )
 
 func ValidatePath(recipePath string) error {
@@ -29,6 +30,11 @@ func ValidatePath(recipePath string) error {
 		wg.Add(1)
 		go func(prop []string) {
 			defer wg.Done()
+			if _, err := os.Stat(prop[0]); os.IsNotExist(err) {
+				errCh <- fmt.Errorf("[FAIL] %s - File not found", prop[0])
+				return
+			}
+
 			file, err := os.Open(prop[0])
 			if err != nil {
 				errCh <- err


### PR DESCRIPTION
When FsGuard tries to check a file that, for whatever reason, isn't present in the specified path anymore, it returns a generic "file not found" error. This commit changes this behavior so that it treats a missing file as a validation error.