### PR TITLE
fix: Change seperator of entries to ,

### DIFF
--- a/core/validate.go
+++ b/core/validate.go
@@ -25,7 +25,7 @@ func ValidatePath(recipePath string) error {
 		if strings.TrimSpace(file) == "" {
 			continue
 		}
-		properties := strings.Split(file, " ")
+		properties := strings.Split(file, ",")
 
 		wg.Add(1)
 		go func(prop []string) {

--- a/signatures
+++ b/signatures
@@ -1,5 +1,5 @@
 ----begin attach----untrusted comment: signature from minisign secret key
-RURSKCy1xSfGW2ru4mJXc1N+1qn1Lao4VSkGnvRgAbkzrHbR5InBHXoxZeMNRP59CIkYvWYjakT5Puedta2O8nqvw2z0brRICwU=
-trusted comment: timestamp:1684445053	file:test_filelist	hashed
-F2ZMLb1/gl8kvMEVclGAeWkCZayURQenEvvStQvOg0KH2ZXuR9ufCAzRnMIKT/tQjPc483/WzYEkOHo9VFYwBw==
-----begin second attach----RWRSKCy1xSfGW8fdFIuMGiuet+t7XblRpBsy6syF6XA7CVUkFN947a23
+RUT/zjj314CS9wT4jPKJ1meN63lbZQBEcTX8UG3bkZAOi4w2p1xcRlKPrAmV+ucbwMxO4zL3+X4HnlGRpnG8gu+I3m8K2baFmgw=
+trusted comment: timestamp:1699035853	file:test_filelist	hashed
+VQQ/o2RoaLOF6DmrlaY23hiDhjY0n0YSrGIYnoQy2dDUvkm+JmHXhlER+H3NY5ZlFSxuEtnQ2oij06hX35dcCg==
+----begin second attach----RWT/zjj314CS9yAR7EeTXdh78ASVkGTU+ax2dWrvrlIOUb26PipAlUqO

--- a/test_filelist
+++ b/test_filelist
@@ -1,4 +1,4 @@
-/usr/sbin/bash 35eab9f2ffe2de924043fe288896c512ed353712 false
-/usr/sbin/tar 1d44d9a12776e7228a8153fae5fd2d2a84419ce1 false
-/usr/bin/sudo 7f1a9b5842d2962fa8fab3973d9ea929ce4106a5 true
-/usr/sbin/ar sotrue,,, false
+/usr/sbin/bash,35eab9f2ffe2de924043fe288896c512ed353712,false
+/usr/sbin/tar,1d44d9a12776e7228a8153fae5fd2d2a84419ce1,false
+/usr/bin/sudo,7f1a9b5842d2962fa8fab3973d9ea929ce4106a5,true
+/usr/sbin/ar,badcheck,false


### PR DESCRIPTION
Uses , instead of a space to seperate filename and hash in the filelist to allow files to have spaces in the path

fixes #7