### PR TITLE
fix: change seperator to #FSG#

### DIFF
--- a/core/validate.go
+++ b/core/validate.go
@@ -25,7 +25,7 @@ func ValidatePath(recipePath string) error {
 		if strings.TrimSpace(file) == "" {
 			continue
 		}
-		properties := strings.Split(file, ",")
+		properties := strings.Split(file, " #FSG #")
 
 		wg.Add(1)
 		go func(prop []string) {

--- a/signatures
+++ b/signatures
@@ -1,5 +1,5 @@
 ----begin attach----untrusted comment: signature from minisign secret key
-RUT/zjj314CS9wT4jPKJ1meN63lbZQBEcTX8UG3bkZAOi4w2p1xcRlKPrAmV+ucbwMxO4zL3+X4HnlGRpnG8gu+I3m8K2baFmgw=
-trusted comment: timestamp:1699035853	file:test_filelist	hashed
-VQQ/o2RoaLOF6DmrlaY23hiDhjY0n0YSrGIYnoQy2dDUvkm+JmHXhlER+H3NY5ZlFSxuEtnQ2oij06hX35dcCg==
-----begin second attach----RWT/zjj314CS9yAR7EeTXdh78ASVkGTU+ax2dWrvrlIOUb26PipAlUqO
+RUTpbAiGx/YxctK3HrTfy1VRfD/qSNxFWemE3LdouaAxL+EPR69qdfrsHxk9oZdlq+f5sg9Z4HcDbN93NHvFqGzq+D4eCJW09AE=
+trusted comment: timestamp:1699212652	file:test_filelist	hashed
+f486WxemqmCVuIRuF6U1ASuNjP2RZMi8fopriCQmeA9ql7lxJRR5SJQlF9db41pYtE3/i/gTD8gwNgBOaHtaAw==
+----begin second attach----RWTpbAiGx/YxchQa2SSfM6rThyyUg5uLjS9QwIoSOTejP6Uw8R+rULn4

--- a/test_filelist
+++ b/test_filelist
@@ -1,4 +1,4 @@
-/usr/sbin/bash,35eab9f2ffe2de924043fe288896c512ed353712,false
-/usr/sbin/tar,1d44d9a12776e7228a8153fae5fd2d2a84419ce1,false
-/usr/bin/sudo,7f1a9b5842d2962fa8fab3973d9ea929ce4106a5,true
-/usr/sbin/ar,badcheck,false
+/usr/sbin/bash #FSG# 35eab9f2ffe2de924043fe288896c512ed353712 #FSG# false
+/usr/sbin/tar #FSG# 1d44d9a12776e7228a8153fae5fd2d2a84419ce1 #FSG# false
+/usr/bin/sudo #FSG# 7f1a9b5842d2962fa8fab3973d9ea929ce4106a5 #FSG# true
+/usr/sbin/ar #FSG# badcheck #FSG# false


### PR DESCRIPTION
Changes the seperator in the filelist to #FSG# instead of ,