### PR TITLE
fix: exit with non-zero returncode when failing

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+    "os"
 )
 
 var rootCmd = &cobra.Command{
@@ -13,6 +14,10 @@ func init() {
 	rootCmd.AddCommand(NewVerifyCommand())
 }
 
-func Execute() error {
-	return rootCmd.Execute()
+func Execute() {
+    // cobra does not exit with a non-zero return code when failing
+    // solution from https://github.com/spf13/cobra/issues/221 
+    if err := rootCmd.Execute(); err != nil {
+        os.Exit(1)
+    }
 }


### PR DESCRIPTION
Makes FsGuard exit with a non-zero exit code when failing verification.